### PR TITLE
Revert "Accept io.Reader instead of []byte"

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -1,9 +1,6 @@
 package apngdetector
 
-import (
-	"bytes"
-	"io"
-)
+import "bytes"
 
 const (
 	//Image header
@@ -16,29 +13,23 @@ const (
 	actl = "acTL"
 )
 
-// Detect checks, if an acTL follows between IHDR and first IDAT
-func Detect(r io.Reader) (isAPNG bool, err error) {
-	img := make([]byte, 512)
-	_, err = r.Read(img)
-	if err != nil {
-		return
-	}
+//check if an acTL follows between IHDR and first IDAT
+func Detect(img []byte) bool {
 	index := bytes.Index(img, []byte(ihdr))
 	if index == -1 {
-		return
+		return false
 	}
 	//Cut head off
 	img = img[index:]
 
 	index = bytes.Index(img, []byte(idat))
 	if index == -1 {
-		return
+		return false
 	}
 	//Cut tail off
 	img = img[:index]
 
 	index = bytes.Index(img, []byte(actl))
 	//whether found the APNG header in the right location
-	isAPNG = index != -1
-	return
+	return index != -1
 }

--- a/detector_test.go
+++ b/detector_test.go
@@ -1,7 +1,7 @@
 package apngdetector
 
 import (
-	"os"
+	"io/ioutil"
 	"testing"
 )
 
@@ -16,16 +16,11 @@ func TestDetector(t *testing.T) {
 		{"infinite2frame.png", true},
 	}
 	for _, test := range tests {
-		file, err := os.Open(test.filename)
+		file, err := ioutil.ReadFile(test.filename)
 		if err != nil {
 			panic(err)
 		}
-
-		isApng, err := Detect(file)
-		if err != nil {
-			panic(err)
-		}
-		if isApng != test.expected {
+		if Detect(file) != test.expected {
 			t.Fatal(test)
 		}
 	}


### PR DESCRIPTION
This reverts commit 9a14710f6dfb5e33817d7e504f615ead1e7cff9f.

I realized that last PR was a mistake. You would almost never want to pass an io.Reader to Detect, because you will want only the start of a file, not a reader in an arbitrary position. This also produces more allocations, because you now have to allocate a 512 length []byte. And it thwarts concurrency, because you can't read the same reader from two goroutines. So, if you want to perform thumbnailing and APNG detection at the same time, you will have to create a new bytes.Reader, so that's an extra allocation. Yeah, sorry about that! Any thoughts on this?  
